### PR TITLE
Retorna pré-diagnóstico traduzido e descrição no endpoint /cadastrar-lesao

### DIFF
--- a/project/app/api/routes/atendimento_routes.py
+++ b/project/app/api/routes/atendimento_routes.py
@@ -396,7 +396,7 @@ async def cadastrar_lesao(
     descricao_lesao: str = Form(...),
     files: List[UploadFile] = File(None),
     db: AsyncSession = Depends(get_db),
-    #current_user: models.User = Depends(require_role(RoleEnum.PESQUISADOR))
+    current_user: models.User = Depends(require_role(RoleEnum.PESQUISADOR))
 ):
     # Verify atendimento exists
     stmt = select(models.Atendimento).filter(models.Atendimento.id == atendimento_id)
@@ -427,6 +427,7 @@ async def cadastrar_lesao(
     imagens_urls = []
     tipos = []
     diagnosticos = []
+    descricoes_lesao = []
     if files:      
         for file in files:
             try:
@@ -444,12 +445,13 @@ async def cadastrar_lesao(
                 file_content = await file.read()  # Lê o arquivo em memória
 
                 # Classificação da imagem
-                diagnostico = await classificar_imagem_pele(file_content)  # Passa o conteúdo lido para a função
-                diagnosticos.append(diagnostico)
+                diagnostico = await classificar_imagem_pele(file_content)
+                diagnosticos.append(diagnostico["nome_traduzido"])
+                descricoes_lesao.append(diagnostico["descricao"])
                 print(f"Imagem {file.filename} classificada com sucesso como {diagnostico}.")
 
                 # Classificação do tipo de lesão
-                tipo = await classificar_tipo_lesao(file_content)  # Passa o conteúdo lido para a função
+                tipo = await classificar_tipo_lesao(file_content)
                 tipos.append(tipo)
                 print(f"Imagem {file.filename} classificada com sucesso como tipo {tipo}.")
             except Exception as e:
@@ -467,8 +469,9 @@ async def cadastrar_lesao(
             "descricao_lesao": new_lesao.descricao_lesao,
         },
         "imagens": imagens_urls,
-        "tipo": tipos,
-        "prediagnosticos": diagnosticos 
+        "tipos": tipos,
+        "prediagnosticos": diagnosticos, 
+        "descricoes-lesao": descricoes_lesao
     }
 
 @router.get("/listar-lesoes/{atendimento_id}")

--- a/project/app/utils/data/lesoes.json
+++ b/project/app/utils/data/lesoes.json
@@ -1,0 +1,30 @@
+{
+  "benign_keratosis-like_lesions": {
+    "nome": "Lesões tipo ceratose benigna",
+    "descricao": "Lesões de pele geralmente não cancerígenas, como a ceratose seborreica e lentigo solar, comuns em pessoas mais velhas."
+  },
+  "basal_cell_carcinoma": {
+    "nome": "Carcinoma basocelular",
+    "descricao": "O tipo mais comum de câncer de pele, geralmente de crescimento lento e pouco provável de se espalhar, mas pode causar danos locais."
+  },
+  "actinic_keratoses": {
+    "nome": "Ceratose actínica",
+    "descricao": "Lesões pré-cancerosas causadas pela exposição ao sol, que podem evoluir para carcinoma espinocelular se não forem tratadas."
+  },
+  "vascular_lesions": {
+    "nome": "Lesões vasculares",
+    "descricao": "Alterações nos vasos sanguíneos da pele, como hemangiomas e pontos rubis, geralmente benignas."
+  },
+  "melanocytic_Nevi": {
+    "nome": "Nevo melanocítico",
+    "descricao": "Popularmente conhecidos como pintas, são aglomerados de células produtoras de pigmento; normalmente benignos."
+  },
+  "melanoma": {
+    "nome": "Melanoma",
+    "descricao": "Um tipo agressivo de câncer de pele que se origina nos melanócitos; pode se espalhar rapidamente se não tratado precocemente."
+  },
+  "dermatofibroma": {
+    "nome": "Dermatofibroma",
+    "descricao": "Lesão benigna firme da pele, normalmente causada por traumas menores como picadas de inseto ou cortes."
+  }
+}

--- a/project/app/utils/machine_learning.py
+++ b/project/app/utils/machine_learning.py
@@ -2,17 +2,25 @@ from transformers import AutoImageProcessor, AutoModelForImageClassification
 from PIL import Image
 import torch
 import io
+import json
+import os
 from fastapi import UploadFile
 
+# Carrega modelo
 processor = AutoImageProcessor.from_pretrained("Anwarkh1/Skin_Cancer-Image_Classification")
 model = AutoModelForImageClassification.from_pretrained("Anwarkh1/Skin_Cancer-Image_Classification")
 
-async def classificar_imagem_pele(file_content: bytes) -> str:
+# Carrega o JSON uma única vez
+caminho_json = os.path.join(os.path.dirname(__file__), "data", "lesoes.json")
+with open(caminho_json, "r", encoding="utf-8") as f:
+    descricoes_lesoes = json.load(f)
+
+async def classificar_imagem_pele(file_content: bytes) -> dict:
     try:
         imagem = Image.open(io.BytesIO(file_content)).convert("RGB")
         imagem = imagem.resize((224, 224))
         inputs = processor(images=imagem, return_tensors="pt", padding=True)
-        
+
         with torch.no_grad():
             outputs = model(**inputs)
             logits = outputs.logits
@@ -20,7 +28,21 @@ async def classificar_imagem_pele(file_content: bytes) -> str:
 
         predicted_label = model.config.id2label[predicted_class_idx]
 
-        return predicted_label
+        # Busca no JSON
+        info = descricoes_lesoes.get(predicted_label, {
+            "nome": "Desconhecido",
+            "descricao": "Não foi possível encontrar uma descrição para esta classificação."
+        })
+
+        return {
+            "classe_original": predicted_label,
+            "nome_traduzido": info["nome"],
+            "descricao": info["descricao"]
+        }
     except Exception as e:
         print(f"Erro ao classificar a imagem: {str(e)}")
-        return "Erro ao classificar a imagem"
+        return {
+            "classe_original": None,
+            "nome_traduzido": "Erro",
+            "descricao": "Erro ao classificar a imagem"
+        }


### PR DESCRIPTION

# 🚀 Descrição

Altera o endpoint /cadastrar-lesao para que ele retorne o pré-diagnóstico traduzido e também uma breve descrição da lesão.
---

# 📋 Tipo de mudança

<!-- Marque com "x" as opções que se aplicam -->

- [ ] 🐛 Bugfix (corrige um problema)
- [X] ✨ Nova funcionalidade
- [ ] ♻️ Refatoração de código (nenhuma funcionalidade alterada)
- [ ] 📚 Atualização de documentação
- [ ] 🔧 Configuração ou infraestrutura
- [ ] 🧪 Testes adicionados ou atualizados
- [ ] Outro: _______

---

# ✅ Checklist

<!-- Garanta que todas as etapas abaixo foram seguidas -->

- [X] O código segue o padrão de estilo do projeto
- [X] Foi testado localmente
- [X] Todos os testes existentes passaram
- [X] Foram adicionados testes relacionados, se necessário
- [X] A documentação foi atualizada (se necessário)
- [X] A branch está atualizada com a `main` ou `dev`

---

# 🧪 Como testar

```
curl --location 'http://localhost:8004/cadastrar-lesao' \
--form 'atendimento_id="2"' \
--form 'local_lesao_id="2"' \
--form 'descricao_lesao="teste teste teste"' \
--form 'files=@"ISIC_0011865.jpg"'
```
---

